### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+    "authors": [
+        "Alex Suleap"
+    ],
+    "name": "angular-tree-widget",
+    "description": "Light AngularJS tree widget control, without jQuery dependency.",
+    "keywords": [
+        "angular",
+        "tree"
+    ],
+    "license": "MIT",
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "lib",
+        "demo"
+    ],
+    "main": [        
+        "dist/angular-tree-widget.min.js",
+        "dist/angular-tree-widget.min.css"
+    ],
+    "dependencies": {
+        "angular": "~1.4.9",
+        "angular-animate": "~1.4.9",
+        "angular-recursion": "~1.0.5"
+    }
+}


### PR DESCRIPTION
bower.json added.

To publish the component in bower you should:

1. Follow [this guide](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) to create a ssh key for your github account (if you don't did it before).
2. Follow this guide [Bower registry](https://bower.io/docs/creating-packages/#register) to publish the component.